### PR TITLE
Implemented rules for moving from middle bar

### DIFF
--- a/game/app.py
+++ b/game/app.py
@@ -39,7 +39,7 @@ class App:
         self.points[12] = [Piece("white", self.screen, self.board.point_width, self.board.triangle_height) for _ in range(5)]
 
         #define a white and black stack in the center (mid) - for the eaten pieces
-        self.mid = [[] for _ in range(2)]
+        self.mid = [[] for _ in range(2)] #stack index 0 represents white pieces
 
         # Calculate positions for each piece
         self.positions = list()
@@ -81,17 +81,23 @@ class App:
         # Remove piece from its current point, therefore the algorithm used is deletion
         # Time Complexity is O(n) for removing pieces in both the worst and average case, where n is the average number of pieces
         # Because if one element is removed from the middle of the list, all the elements to its right need to shift to fill the gap
-        for point in self.points:
-            if piece in point:
-                point.remove(piece)
-                break
+        if new_point_index == -1:
+            piece.eat(self.screen, len(self.mid[1])) #black 
+        elif new_point_index == 24:
+            piece.eat(self.screen, len(self.mid[0]))
 
-        # Add piece to the new point
-        if not piece.beared_off:
-            # Time Complexity is O(1) in both the worst and average case
-            # As adding an element to the end of the list has a constant time
-            self.points[new_point_index].append(piece)
-        
+        else:
+            for point in self.points:
+                if piece in point:
+                    point.remove(piece)
+                    break
+
+            # Add piece to the new point
+            if not piece.beared_off:
+                # Time Complexity is O(1) in both the worst and average case
+                # As adding an element to the end of the list has a constant time
+                self.points[new_point_index].append(piece)
+            
     def calculate_piece_position(self, point_id: int, stack_height: int):
         # Position for bearing off (you can adjust this based on your game design)
         if point_id == -1:
@@ -145,8 +151,12 @@ class App:
         for point_index, point in enumerate(self.points):
             if piece in point:
                 return point_index
+        # check if the piece is in mid stack:
+        if piece in self.mid[1]:
+            return -1 
+        elif piece in self.mid[0]:
+            return 24
         return -1
-        
 
     def restack_pieces_at_point(self, point_index):
         for stack_index, piece in enumerate(self.points[point_index]):
@@ -229,7 +239,7 @@ class App:
     """
     Eaten Logic
     """
-    def can_be_eaten(self, piece: Piece, new_point_index: int, move_distance: int) -> bool:
+    def can_be_moved(self, piece: Piece, new_point_index: int, move_distance: int) -> bool:
         correct_stack = False
         eat = False
 
@@ -267,24 +277,31 @@ class App:
         # Tries moving a piece to a new position based on the value shown in the dice
         original_point_index = self.find_piece_point_index(piece)
         move_distance = self.calculate_move_distance(piece, new_point_index)
-        # Check for bearing off
-        if self.can_bear_off(self.current_player):
-            if self.is_valid_bear_off_move(original_point_index, move_distance):
-                # To deal non exact bearing moves
-                dice_value_to_remove = self.dice.get_closest_dice_value(move_distance)
-                if dice_value_to_remove is not None:
-                    # Bear off the piece
-                    self.bear_off_piece(piece)
-                    self.dice.current_face_values.remove(dice_value_to_remove)
-                    self.change_turn()
-                    return True
+        #This conditional allows you to only move pieces if there is nothing in the middle
+        #If there is a piece in the middle, and you are not moving it, the piece will not enter this if, and it will get reset to the original position
+        if (self.current_player == 'black' and len(self.mid[1]) == 0) or (self.current_player == 'white' and len(self.mid[0]) == 0) or original_point_index == (-1 or 24):
+            # Check for bearing off
+            if self.can_bear_off(self.current_player):
+                if self.is_valid_bear_off_move(original_point_index, move_distance):
+                    # To deal non exact bearing moves
+                    dice_value_to_remove = self.dice.get_closest_dice_value(move_distance)
+                    if dice_value_to_remove is not None:
+                        # Bear off the piece
+                        self.bear_off_piece(piece)
+                        self.dice.current_face_values.remove(dice_value_to_remove)
+                        self.change_turn()
+                        return True
 
-        
-        if self.can_be_eaten(piece, new_point_index, move_distance):
-            self.update_piece_position(piece, new_point_index)
-            self.dice.current_face_values.remove(move_distance)
-            self.change_turn()
-            return True
+            if self.can_be_moved(piece, new_point_index, move_distance):
+                self.update_piece_position(piece, new_point_index)
+                if original_point_index == -1:
+                    self.mid[1].remove(piece)
+                elif original_point_index == 24:
+                    self.mid[0].remove(piece)
+                self.dice.current_face_values.remove(move_distance)
+                self.change_turn()
+                return True
+        print(len(self.mid[1]))
         
         
         # Move the piece back to its original position if no other valid move
@@ -347,19 +364,19 @@ class App:
             # Logic to end the current player's turn and switch to the other player
             self.button.set_clicked(False)
             self.current_player = 'white' if self.current_player == 'black' else 'black'
-            if self.current_player == 'black':
-                mid_pos = 1
-            elif self.current_player == 'white':
-                mid_pos = 0
-            able_to_reset = True
-            while len(self.mid[mid_pos]) != 0 and able_to_reset:
-                piece_to_delete = self.mid[mid_pos].pop() #this takes care of the backend
-                able_to_reset = self.reset_position(self.screen, piece_to_delete) #this returns the ith element in the stack, 
-                #which will get blitted with reset_position() #this also tells us whether we can append the piece based on the logic conditions.
-                #above, we just popped the piece, without checking the conditions to do so, 
-                #so, if the condition is not met, we must reappend it. 
-                if able_to_reset == False:
-                    self.mid[mid_pos].append(piece_to_delete)
+            # if self.current_player == 'black':
+            #     mid_pos = 1
+            # elif self.current_player == 'white':
+            #     mid_pos = 0
+            # able_to_reset = True
+            # while len(self.mid[mid_pos]) != 0 and able_to_reset:
+            #     piece_to_delete = self.mid[mid_pos].pop() #this takes care of the backend
+            #     able_to_reset = self.reset_position(self.screen, piece_to_delete) #this returns the ith element in the stack, 
+            #     #which will get blitted with reset_position() #this also tells us whether we can append the piece based on the logic conditions.
+            #     #above, we just popped the piece, without checking the conditions to do so, 
+            #     #so, if the condition is not met, we must reappend it. 
+            #     if able_to_reset == False:
+            #         self.mid[mid_pos].append(piece_to_delete)
 
     def check_win_condition(self):
         if self.board.counter_white == 15:  # Assuming 15 pieces per player

--- a/game/piece.py
+++ b/game/piece.py
@@ -79,9 +79,9 @@ class Piece:
         self.eaten = True
 
         if self.colour == "black":
-            self.rect.center = ((self.screen.get_width() // 2) - 0.08*self.screen.get_width(), (self.screen.get_height() // 2)-0.01 * self.image.get_height() // 2)
+            self.rect.center = ((self.screen.get_width() // 2) - 0.08*self.screen.get_width(), (self.screen.get_height() // 2)+3 * self.image.get_height() // 2)
         else:
-            self.rect.center = ((self.screen.get_width()  // 2)- 0.04*self.screen.get_width(), (self.screen.get_height() // 2)-0.01 * self.image.get_height() // 2) 
+            self.rect.center = ((self.screen.get_width()  // 2)- 0.04*self.screen.get_width(), (self.screen.get_height() // 2)+3 * self.image.get_height() // 2) 
         screen.blit(self.image, self.rect.center)
 
     def handle_event(self, event, app, dice: Dice):


### PR DESCRIPTION
I put conditions for movement when there are pieces in the middle stack, so that the user is forced to deal with the pieces from the middle stack before other pieces.
Please note: this does not work when there are white pieces in the middle, as the bot does not know what to do when there is a stack -1 or 24 (out of range). 
Perhaps you can try fixing this in the bot code (give the bot the option to move the middle pieces) or we can just avoid eating the bot.